### PR TITLE
Define group for customize

### DIFF
--- a/flycheck-cstyle.el
+++ b/flycheck-cstyle.el
@@ -36,6 +36,10 @@
 ;;; Code:
 (require 'flycheck)
 
+(defgroup flycheck-cstyle nil
+  "Integrate cstyle with flycheck."
+  :group 'flycheck)
+
 (defcustom flycheck-cstyle-config
   "~/.cstyle"
   "Configuration to use with cstyle.")


### PR DESCRIPTION
This also fixes byte-compile warnings.

```
flycheck-cstyle.el:39:1:Warning: defcustom for `flycheck-cstyle-config' fails
    to specify containing group
flycheck-cstyle.el:39:1:Warning: defcustom for `flycheck-cstyle-config' fails
    to specify containing group
```
